### PR TITLE
drop sound_api global legacy support as not known to be used

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -5,9 +5,6 @@ xcompat = {
     materials = dofile(modpath .. "/src/materials.lua"),
 }
 
---this exists for legacy compat reasons
-sound_api = xcompat.sounds -- luacheck: ignore
-
 local function validate_sound(key)
     if key and xcompat.sounds[key] then
         return true


### PR DESCRIPTION
see https://content.minetest.net/zipgrep/a68dc3d9-5fe4-4e24-97fe-e94e7a69d81a/

removes support for old `sound_api.function()` as it appears no one used it