### PR TITLE
register tests only if enabled

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -44,7 +44,7 @@ end)
 
 dofile(modpath .. "/src/commands.lua")
 
-if minetest.get_modpath("mtt") then
+if minetest.get_modpath("mtt") and mtt.enabled then
     -- register tests
     dofile(modpath .. "/mtt.lua")
 end

--- a/mtt.lua
+++ b/mtt.lua
@@ -4,4 +4,7 @@ mtt.emerge_area({ x=0, y=0, z=0 }, { x=10, y=10, z=10 })
 
 -- check nodelist
 local mtt_nodelist = minetest.settings:get("mtt_nodelist")
-mtt.validate_nodenames(minetest.get_modpath("xcompat") .. "/test/nodelist/" .. mtt_nodelist)
+if mtt_nodelist then
+    -- nodelist specified, check if all the required nodes are present
+    mtt.validate_nodenames(minetest.get_modpath("xcompat") .. "/test/nodelist/" .. mtt_nodelist)
+end


### PR DESCRIPTION
this PR adds a check to only register the `mtt` checks if the mod was enabled in the first place (ci, manually in the minetest config)

otherwise the tests get registered it tries to concatenate the value of the `mtt_nodelist` setting (used for dynamic selection for the present nodes) and it might crash with a [nil-error](https://github.com/pandorabox-io/pandorabox-mods/pull/3760)