### PR TITLE
fix mineclonia ci

### DIFF
--- a/test/nodelist/mineclonia.txt
+++ b/test/nodelist/mineclonia.txt
@@ -231,7 +231,6 @@ homedecor:kitchen_cabinet_colorable_marble_locked
 homedecor:kitchen_cabinet_colorable_marble
 pipeworks:lua_tube101001
 homedecor:banister_wood_diagonal_right_sapphire
-mcl_trees:sapling_bamboo
 homedecor:banister_wood_diagonal_right_blue
 pipeworks:lua_tube111001
 mcl_heads:steve_wall


### PR DESCRIPTION
from cora on mineclonia discord

> they were removed on purpose because not actually existing in mc (they were never supposed to be obtainable in game either, although at some point the wandering trader sold them i think)