### PR TITLE
Fix typos in mcl item names and allow for mcl variant differences

### DIFF
--- a/src/materials/mineclonia.lua
+++ b/src/materials/mineclonia.lua
@@ -12,22 +12,19 @@ local materials = {
     steel_ingot = "mcl_core:iron_ingot",
     gold_ingot = "mcl_core:gold_ingot",
     tin_ingot = "mcl_core:iron_ingot",
-    copper_block = "mcl_copper:copper_block",
-    steel_block = "mcl_core:iron_block",
-    gold_block = "mcl_core:gold_block",
-    tin_block = "mcl_core:iron_block",
+    copper_block = "mcl_copper:block",
+    steel_block = "mcl_core:ironblock",
+    gold_block = "mcl_core:goldblock",
+    tin_block = "mcl_core:ironblock",
     axe_steel = "mcl_core:axe_steel",
     axe_diamond = "mcl_core:axe_diamond",
     axe_bronze = "mcl_core:axe_bronze",
     axe_stone = "mcl_core:axe_stone",
     axe_wood = "mcl_core:axe_wood",
     pick_steel = "mcl_core:pick_steel",
-    mese = "mesecons_torch:redstoneblock",
-    mese_crystal = "mesecons:redstone",
-    mese_crystal_fragment = "mcl_core:iron_ingot",
     torch = "mcl_torches:torch",
     diamond = "mcl_core:diamond",
-    clay_lump = "default:clay_lump",
+    clay_lump = "mcl_core:clay_lump",
     water_bucket = "mcl_buckets:bucket_water",
     empty_bucket = "mcl_buckets:bucket_empty",
     dye_dark_grey = mcl_dyes_name .. ":dark_grey",
@@ -48,8 +45,8 @@ local materials = {
     silicon = "mcl_core:iron_ingot",
     string = "mcl_mobitems:string",
     paper = "mcl_core:paper",
-    book = "mcl_core:book",
-    iron_lump = "mcl_core:stone_with_iron",
+    book = "mcl_books:book",
+    iron_lump = "mcl_raw_ores:raw_iron",
     wool_grey = "mcl_wool:grey",
     wool_green = "mcl_wool:green",
     wool_dark_green = "mcl_wool:dark_green",
@@ -60,8 +57,8 @@ local materials = {
     slab_wood = "mcl_stairs:slab_wood",
     glass = "mcl_core:glass",
     glass_block = "mcl_core:glass",
-    glass_bottle = "mcl_core:glass_bottle",
-    coal_lump = "mcl_core:coal",
+    glass_bottle = "mcl_potions:glass_bottle",
+    coal_lump = "mcl_core:coal_lump",
     stone = "mcl_core:stone",
     desert_stone = "mcl_core:redsandstone",
     desert_sand = "mcl_core:sand",
@@ -73,16 +70,37 @@ local materials = {
     water_flowing = "mcl_core:water_flowing",
     dirt = "mcl_core:dirt",
     dirt_with_grass = "mcl_core:dirt_with_grass",
-    apple_leaves = "mcl_trees:leaves_oak",
-    apple_log = "mcl_trees:tree_oak",
-    apple_planks = "mcl_trees:wood_oak",
-    birch_leaves = "mcl_trees:leaves_birch",
-    birch_log = "mcl_trees:tree_birch",
-    birch_planks = "mcl_trees:wood_birch",
-    jungle_leaves = "mcl_trees:leaves_jungle",
     bowl = "mcl_core:bowl",
     stick = "mcl_core:stick",
 }
+
+if minetest.get_modpath("mcl_redstone") then
+    materials.mese = "mcl_redstone_torch:redstoneblock"
+    materials.mese_crystal = "mcl_redstone:redstone"
+    materials.mese_crystal_fragment = "mcl_core:iron_ingot"
+else
+    materials.mese = "mesecons_torch:redstoneblock"
+    materials.mese_crystal = "mesecons:redstone"
+    materials.mese_crystal_fragment = "mcl_core:iron_ingot"
+end
+
+if minetest.get_modpath("mcl_trees") then
+    materials.apple_leaves = "mcl_trees:leaves_oak"
+    materials.apple_log = "mcl_trees:tree_oak"
+    materials.apple_planks = "mcl_trees:wood_oak"
+    materials.birch_leaves = "mcl_trees:leaves_birch"
+    materials.birch_log = "mcl_trees:tree_birch"
+    materials.birch_planks = "mcl_trees:wood_birch"
+    materials.jungle_leaves = "mcl_trees:leaves_jungle"
+else
+    materials.apple_leaves = "mcl_core:leaves"
+    materials.apple_log = "mcl_core:tree"
+    materials.apple_planks = "mcl_core:wood"
+    materials.birch_leaves = "mcl_core:birchleaves"
+    materials.birch_log = "mcl_core:birchtree"
+    materials.birch_planks = "mcl_core:birchwood"
+    materials.jungle_leaves = "mcl_core:jungleleaves"
+end
 
 if minetest.get_modpath("moreores") then
     materials.tin_ingot = "moreores:tin_ingot"


### PR DESCRIPTION
This fixes #46 as well as other typos I found.

It also now knows about the differences between mcla and vl  concerning redstone and trees/leaves.

Didn't really test everything, but I think it has less errors now:-)